### PR TITLE
[#62889580] Add ability to authenticate with tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current
+
+Features:
+
+- Requires vCloud Core v0.0.11 which allows use of FOG_VCLOUD_TOKEN via ENV to authenticate, as an alternative to a .fog file
+
 ## 0.0.2 (2014-04-04)
 
   - First release of gem

--- a/README.md
+++ b/README.md
@@ -36,34 +36,64 @@ Or install it yourself as:
 
 ## Usage
 
-vCloud Launcher uses [Fog](http://fog.io/).
+`vcloud-launch node.yaml`
 
-To use it you need a .fog file in your home directory.
+## Credentials
+
+vCloud Launcher uses [Fog](http://fog.io/). To use it you'll need to give it credentials that allow it to talk to a VMware environment. Fog offers two ways to do this.
+
+### 1. Create a `.fog` file containing your credentials
+
+To use this method, you need a `.fog` file in your home directory.
 
 For example:
 
-test:
-  vcloud_director_username: 'username@org_name'
-  vcloud_director_password: 'password'
-  vcloud_director_host: 'host.api.example.com'
+    test:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.example.com'
 
 Unfortunately current usage of fog requires the password in this file. Multiple sets of credentials can be specified in the fog file, using the following format:
 
-test:
-  vcloud_director_username: 'username@org_name'
-  vcloud_director_password: 'password'
-  vcloud_director_host: 'host.api.example.com'
+    test:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.example.com'
 
-test2:
-  vcloud_director_username: 'username@org_name'
-  vcloud_director_password: 'password'
-  vcloud_director_host: 'host.api.vendor.net'
+    test2:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.vendor.net'
 
-You can then pass the FOG_CREDENTIAL environment variable at the start of your command. The value of the FOG_CREDENTIAL environment variable is the name of the credential set in your fog file which you wish to use. For instance:
+You can then pass the `FOG_CREDENTIAL` environment variable at the start of your command. The value of the `FOG_CREDENTIAL` environment variable is the name of the credential set in your fog file which you wish to use.  For instance:
 
-FOG_CREDENTIAL=test2 vcloud-launch node.yaml
+    FOG_CREDENTIAL=test2 bundle exec vcloud-launch node.yaml
 
-An example configuration file is located in examples/vcloud-launch
+To understand more about `.fog` files, visit the 'Credentials' section here => http://fog.io/about/getting_started.html.
+
+### 2. Log on externally and supply your session token
+
+You can choose to log on externally by interacting independently with the API and supplying your session token to the
+tool by setting the `FOG_VCLOUD_TOKEN` ENV variable. This option reduces the risk footprint by allowing the user to
+store their credentials in safe storage. The default token lifetime is '30 minutes idle' - any activity extends the life by another 30 mins.
+
+A basic example of this would be the following:
+
+    curl
+       -D-
+       -d ''
+       -H 'Accept: application/*+xml;version=5.1' -u '<user>@<org>'
+       https://host.com/api/sessions
+
+This will prompt for your password.
+
+From the headers returned, select the header below
+
+     x-vcloud-authorization: AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF=
+
+Use token as ENV var FOG_VCLOUD_TOKEN
+
+    FOG_VCLOUD_TOKEN=AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF= bundle exec ...
 
 ## Contributing
 

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.9'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
This functionality was added to vCloud Core after I began pulling out the vCloud Launcher, so the version bump and the instructions were added to vCloud Tools and are not present in vCloud Launcher. I was going to cherry-pick the commits from the vCloud Tools PR https://github.com/alphagov/vcloud-tools/pull/178 into this repo, but given the conflicts with Jeweller etc and the fact that the changes are very minor, it is simpler just to reapply them here.

Also update CHANGELOG but no need to bump version yet.
