### PR TITLE
bug-fix: added fs_file to extra_disk schema

### DIFF
--- a/lib/vcloud/launcher/vm_orchestrator.rb
+++ b/lib/vcloud/launcher/vm_orchestrator.rb
@@ -58,6 +58,7 @@ module Vcloud
                 internals: {
                   name: { type: 'string', required: false },
                   size: { type: 'string_or_number', required: false },
+                  fs_file: { type: 'string', required: false },
                 },
               },
             },


### PR DESCRIPTION
fs_file is used in ida-boxes in preamble script but schema does not
allow it.
fixing it by adding it to schema

Pair: Jinn/ Sneha
