### PR TITLE
Revert "Gitignore files generated by integration tests."

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ coverage/
 results.html
 fog_integration_test.config
 .idea
-spec/integration/launcher/data/output_*


### PR DESCRIPTION
This reverts commit 4f0cb4341d878d25b51d01fd3c09dd461cb5c179, as requested, 
