### PR TITLE
[#69700312] Bump vCloud Core version to use progress bar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## Current
+## 0.0.3 (2014-04-22)
 
 Features:
 
-- Requires vCloud Core v0.0.11 which allows use of FOG_VCLOUD_TOKEN via ENV to authenticate, as an alternative to a .fog file
+- Allows use of FOG_VCLOUD_TOKEN via ENV to authenticate, as an alternative to a .fog file
+
+Bugfixes:
+
+ - Requires vCloud Core v0.0.12 which fixes issue with progress bar falling over when progress is not returned
 
 ## 0.0.2 (2014-04-04)
 

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
   end
 end

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Our supplier's update to 5.5 exposed an issue where the progress bar fell over when there was no progress to report. This was fixed in https://github.com/fog/fog/pull/2837 and released in Fog 1.22.0, so this commit bumps the version of vCloud Core required. It also bumps the vCloud Launcher version because the earlier version will not work against a 5.5 environment even if you specify using the 5.1 API.

Requires https://github.com/alphagov/vcloud-core/pull/19 to have been merged first.
