### PR TITLE
Create `integration` task as alias for `:all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Runs the unit and feature tests (pretty quick right now)
 * Integration tests ('quick' tests): `bundle exec rake integration:quick`
 * Integration tests (all tests - takes 20mins+): `bundle exec rake integration:all`
 
+NB. `bundle exec rake integration` is an alias for `bundle exec rake integration:all`.
+
 You need access to a suitable vCloud Director organization to run the
 integration tests. It is not necessarily safe to run them against an existing
 environment, unless care is taken with the entities being tested.

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rspec/core/rake_task'
 require 'gem_publisher'
 
 task :default => [:spec,:features]
+task :integration => ['integration:all']
 
 RSpec::Core::RakeTask.new(:spec) do |task|
   # Set a bogus Fog credential, otherwise it's possible for the unit


### PR DESCRIPTION
All the other vCloud Tools have an `integration` rake task. Because the full integration tasks for launcher take a very long time, we have a `integration:quick` and an `integration:all` task.

This commit creates an `integration` task that is an alias for `integration:all`, so that a user new to this tool but familiar with the others can run tests. If they find the tests take too long they can investigate further (perhaps by reading the README) to find the `integration:quick` task.
