### PR TITLE
[#70513870] Standardise testing section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,17 @@ If you want to be sure you are pinning to 5.1, or use 5.5, you can set the API v
 
 ## Testing
 
-Default target: `bundle exec rake`
-Runs the unit and feature tests (pretty quick right now)
+Run the default suite of tests (e.g. lint, unit, features):
 
-* Unit tests only: `bundle exec rake spec`
-* Feature tests only: `bundle exec rake features`
-* Integration tests ('quick' tests): `bundle exec rake integration:quick`
-* Integration tests (all tests - takes 20mins+): `bundle exec rake integration:all`
+    bundle exec rake
 
-NB. `bundle exec rake integration` is an alias for `bundle exec rake integration:all`.
+Run the integration tests (slower and requires a real environment):
+
+    bundle exec rake integration
+
+Run the integration tests minus some that are very slow:
+
+    bundle exec rake integration:quick
 
 You need access to a suitable vCloud Director organization to run the
 integration tests. It is not necessarily safe to run them against an existing


### PR DESCRIPTION
Same as alphagov/vcloud-core@c8a2318f33b12828416c3a963ad0462ff4d8f906

I've omitted the fact that `integration` is aliased to `integration:all`
because I don't think most people need to know that. They can look in the
Rakefile if they're so inclined.

Retained an extra line about the quick tests though.
