### PR TITLE
[#70508876 ] Use subject in VappOrchestrator test

### DIFF
--- a/spec/vcloud/launcher/vapp_orchestrator_spec.rb
+++ b/spec/vcloud/launcher/vapp_orchestrator_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Vcloud::Launcher::VappOrchestrator do
+  # Testing class methods rather than instance methods.
+  let(:subject) { Vcloud::Launcher::VappOrchestrator }
 
   context "provision a vapp" do
 
@@ -21,7 +23,7 @@ describe Vcloud::Launcher::VappOrchestrator do
 
       Vcloud::Core::Vapp.should_receive(:get_by_name_and_vdc_name).with('test-vapp-1', 'test-vdc-1').and_return(existing_vapp)
       Vcloud::Core.logger.should_receive(:info).with('Found existing vApp test-vapp-1 in vDC \'test-vdc-1\'. Skipping.')
-      actual_vapp = Vcloud::Launcher::VappOrchestrator.provision @config
+      actual_vapp = subject.provision @config
       actual_vapp.should_not be_nil
       actual_vapp.should == existing_vapp
     end
@@ -40,7 +42,7 @@ describe Vcloud::Launcher::VappOrchestrator do
       .and_return(mock_vapp)
       Vcloud::Launcher::VmOrchestrator.should_receive(:new).with(mock_fog_vm, mock_vapp).and_return(mock_vm_orchestrator)
 
-      new_vapp = Vcloud::Launcher::VappOrchestrator.provision @config
+      new_vapp = subject.provision @config
       new_vapp.should == mock_vapp
     end
 


### PR DESCRIPTION
To match style of the other unit tests. We need to redefine subject we want
the class rather than an instance of the class (which is what rspec gives us
from the top-level describe) in order to test the class methods. I wonder if
this should be a module instead?
