### PR TITLE
Explicitly remove config parameters repo

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -x
 set -e
 
-rm -f Gemfile.lock
-git clean -fdx
+git clean -ffdx
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake
@@ -10,6 +9,7 @@ bundle exec rake
 # Obtain the integration test parameters
 git clone git@github.gds:gds/vcloud-tools-testing-config.git
 mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration:all
 

--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -x
 set -e
 
-rm -f Gemfile.lock
-git clean -fdx
+git clean -ffdx
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 # Obtain the integration test parameters
 git clone git@github.gds:gds/vcloud-tools-testing-config.git
 mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration:all


### PR DESCRIPTION
This was working, but because the Jenkins job had 'Delete workspace before build starts' checked. Better to be explicit about set-up in code rather than relying on options in Jenkins.

Also, no need to delete `Gemfile.lock` as this is covered by `git clean -x`. (Ref https://github.com/alphagov/vcloud-core/commit/996c140c131b).
