### PR TITLE
[#71591898] Move schemas to constants under Launcher::Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Or install it yourself as:
 
 `vcloud-launch node.yaml`
 
+## Configuration schemas
+
+Configuration schemas can be found in [`lib/vcloud/launcher/schema/`][schema].
+
+[schema]: /lib/vcloud/launcher/schema
+
 ## Credentials
 
 vCloud Launcher is based around [fog](http://fog.io/). To use it you'll need to give it

--- a/lib/vcloud/launcher.rb
+++ b/lib/vcloud/launcher.rb
@@ -1,6 +1,10 @@
 require 'vcloud/fog'
 require 'vcloud/core'
 
+require 'vcloud/launcher/schema/vm'
+require 'vcloud/launcher/schema/vapp'
+require 'vcloud/launcher/schema/launcher_vapps'
+
 require 'vcloud/launcher/launch'
 require 'vcloud/launcher/vm_orchestrator'
 require 'vcloud/launcher/vapp_orchestrator'

--- a/lib/vcloud/launcher/launch.rb
+++ b/lib/vcloud/launcher/launch.rb
@@ -8,7 +8,7 @@ module Vcloud
 
       def run(config_file = nil, cli_options = {})
         set_logging_level(cli_options)
-        config = @config_loader.load_config(config_file, config_schema)
+        config = @config_loader.load_config(config_file, Vcloud::Launcher::Schema::LAUNCHER_VAPPS)
         config[:vapps].each do |vapp_config|
           Vcloud::Core.logger.info("Provisioning vApp #{vapp_config[:name]}.")
           begin
@@ -22,22 +22,6 @@ module Vcloud
           end
 
         end
-      end
-
-      def config_schema
-        {
-          type: 'hash',
-          allowed_empty: false,
-          permit_unknown_parameters: true,
-          internals: {
-            vapps: {
-            type: 'array',
-            required: false,
-            allowed_empty: true,
-            each_element_is: ::Vcloud::Launcher::VappOrchestrator.schema
-          },
-        }
-      }
       end
 
       def set_logging_level(cli_options)

--- a/lib/vcloud/launcher/schema/launcher_vapps.rb
+++ b/lib/vcloud/launcher/schema/launcher_vapps.rb
@@ -1,0 +1,21 @@
+module Vcloud
+  module Launcher
+    module Schema
+
+      LAUNCHER_VAPPS = {
+        type: 'hash',
+        allowed_empty: false,
+        permit_unknown_parameters: true,
+        internals: {
+          vapps: {
+            type: 'array',
+            required: false,
+            allowed_empty: true,
+            each_element_is: Vcloud::Launcher::Schema::VAPP,
+          },
+        },
+      }
+
+    end
+  end
+end

--- a/lib/vcloud/launcher/schema/vapp.rb
+++ b/lib/vcloud/launcher/schema/vapp.rb
@@ -1,0 +1,22 @@
+module Vcloud
+  module Launcher
+    module Schema
+
+      VAPP = {
+        type: 'hash',
+        required: true,
+        allowed_empty: false,
+        internals: {
+          name:               { type: 'string', required: true, allowed_empty: false },
+          vdc_name:           { type: 'string', required: true, allowed_empty: false },
+          catalog:            { type: 'string', deprecated_by: 'catalog_name', allowed_empty: false },
+          catalog_name:       { type: 'string', required: true, allowed_empty: false },
+          catalog_item:       { type: 'string', deprecated_by: 'vapp_template_name', allowed_empty: false },
+          vapp_template_name: { type: 'string', required: true, allowed_empty: false },
+          vm:                 Vcloud::Launcher::Schema::VM,
+        },
+      }
+
+    end
+  end
+end

--- a/lib/vcloud/launcher/schema/vm.rb
+++ b/lib/vcloud/launcher/schema/vm.rb
@@ -1,0 +1,62 @@
+module Vcloud
+  module Launcher
+    module Schema
+
+      VM = {
+        type: 'hash',
+        required: false,
+        allowed_empty: false,
+        internals: {
+          network_connections: {
+            type: 'array',
+            required: false,
+            each_element_is: {
+              type: 'hash',
+              internals: {
+                name: { type: 'string', required: true },
+                ip_address: { type: 'ip_address', required: false },
+              },
+            },
+          },
+          storage_profile: { type: 'string', required: false },
+          hardware_config: {
+            type: 'hash',
+            required: false,
+            internals: {
+              cpu: { type: 'string_or_number', required: false },
+              memory: { type: 'string_or_number', required: false },
+            },
+          },
+          extra_disks: {
+            type: 'array',
+            required: false,
+            allowed_empty: false,
+            each_element_is: {
+              type: 'hash',
+              internals: {
+                name: { type: 'string', required: false },
+                size: { type: 'string_or_number', required: false },
+              },
+            },
+          },
+          bootstrap:   {
+            type: 'hash',
+            required: false,
+            allowed_empty: false,
+            internals: {
+              script_path: { type: 'string', required: false },
+              script_post_processor: { type: 'string', required: false },
+              vars: { type: 'hash', required: false, allowed_empty: true },
+            },
+          },
+          metadata: {
+            type: 'hash',
+            required: false,
+            allowed_empty: true,
+          },
+        },
+      }
+
+    end
+  end
+end

--- a/lib/vcloud/launcher/vapp_orchestrator.rb
+++ b/lib/vcloud/launcher/vapp_orchestrator.rb
@@ -23,23 +23,6 @@ module Vcloud
         vapp
       end
 
-      def self.schema
-        {
-          type: 'hash',
-          required: true,
-          allowed_empty: false,
-          internals: {
-            name:               { type: 'string', required: true, allowed_empty: false },
-            vdc_name:           { type: 'string', required: true, allowed_empty: false },
-            catalog:            { type: 'string', deprecated_by: 'catalog_name', allowed_empty: false },
-            catalog_name:       { type: 'string', required: true, allowed_empty: false },
-            catalog_item:       { type: 'string', deprecated_by: 'vapp_template_name', allowed_empty: false },
-            vapp_template_name: { type: 'string', required: true, allowed_empty: false },
-            vm: Vcloud::Launcher::VmOrchestrator.schema,
-          }
-        }
-      end
-
       def self.extract_vm_networks(config)
         if (config[:vm] && config[:vm][:network_connections])
           config[:vm][:network_connections].collect { |h| h[:name] }

--- a/lib/vcloud/launcher/vm_orchestrator.rb
+++ b/lib/vcloud/launcher/vm_orchestrator.rb
@@ -1,6 +1,7 @@
 module Vcloud
   module Launcher
     class VmOrchestrator
+
       def initialize fog_vm, vapp
         vm_id = fog_vm[:href].split('/').last
         @vm = Core::Vm.new(vm_id, vapp)
@@ -21,63 +22,6 @@ module Vcloud
             vm_config[:bootstrap],
             vm_config[:extra_disks]
         )
-      end
-
-      def self.schema
-        {
-          type: 'hash',
-          required: false,
-          allowed_empty: false,
-          internals: {
-            network_connections: {
-              type: 'array',
-              required: false,
-              each_element_is: {
-                type: 'hash',
-                internals: {
-                  name: { type: 'string', required: true },
-                  ip_address: { type: 'ip_address', required: false },
-                },
-              },
-            },
-            storage_profile: { type: 'string', required: false },
-            hardware_config: {
-              type: 'hash',
-              required: false,
-              internals: {
-                cpu: { type: 'string_or_number', required: false },
-                memory: { type: 'string_or_number', required: false },
-              },
-            },
-            extra_disks: {
-              type: 'array',
-              required: false,
-              allowed_empty: false,
-              each_element_is: {
-                type: 'hash',
-                internals: {
-                  name: { type: 'string', required: false },
-                  size: { type: 'string_or_number', required: false },
-                },
-              },
-            },
-            bootstrap:   {
-              type: 'hash',
-              required: false,
-              allowed_empty: false,
-              internals: {
-                script_path: { type: 'string', required: false },
-                script_post_processor: { type: 'string', required: false },
-                vars: { type: 'hash', required: false, allowed_empty: true },
-              },
-            },
-            metadata: {
-              type: 'hash',
-              required: false,
-              allowed_empty: true,
-            },
-          },
-        }
       end
 
     end


### PR DESCRIPTION
This follows the pattern in use by alphagov/vcloud-edge_gateway, which I
like because it makes it clear that these don't get computed or change at
runtime and allows us to point users at them if they need to know what a
valid configuration looks like.

Like alphagov/vcloud-edge_gateway@b30f91b I have also included a link in the
README so that people can find them.

PS: Additional newline in VmOrchestrator to match other classes.
