### PR TITLE
Fix non-existent file spec for Ruby 2.1.x.

### DIFF
--- a/spec/vcloud/launcher/cli_spec.rb
+++ b/spec/vcloud/launcher/cli_spec.rb
@@ -206,7 +206,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { %w{non-existent.yaml} }
 
       it "raises a descriptive error" do
-        expect(subject.stderr).to eq("No such file or directory - non-existent.yaml")
+        expect(subject.stderr).to match("No such file or directory(?: @ rb_sysopen)? - non-existent.yaml")
         expect(subject.exitstatus).to eq(1)
       end
     end


### PR DESCRIPTION
Ruby 2.1's error messages when faced with non-existent files or directories
have changed compared with earlier versions, as described at
https://bugs.ruby-lang.org/issues/9285

Change the spec to use a regex match, rather than string comparison for
cli spec.

This should fix the failing 2.1.2 Travis test in https://github.com/gds-operations/vcloud-launcher/pull/47
