### PR TITLE
[#67916012] Use new TestSetup interface to access test params

### DIFF
--- a/spec/integration/launcher/launch_spec.rb
+++ b/spec/integration/launcher/launch_spec.rb
@@ -143,7 +143,7 @@ describe Vcloud::Launcher::Launch do
   def define_test_data
     config_file = File.join(File.dirname(__FILE__),
       "../vcloud_tools_testing_config.yaml")
-    parameters = Vcloud::Tools::Tester::TestParameters.new(config_file)
+    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
     {
       vapp_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
       vdc_name: parameters.vdc_1_name,

--- a/spec/integration/launcher/storage_profile_integration_spec.rb
+++ b/spec/integration/launcher/storage_profile_integration_spec.rb
@@ -63,7 +63,7 @@ end
 def define_test_data
   config_file = File.join(File.dirname(__FILE__),
     "../vcloud_tools_testing_config.yaml")
-  parameters = Vcloud::Tools::Tester::TestParameters.new(config_file)
+  parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
   {
     vapp_name_1: "vdc-1-sp-#{Time.now.strftime('%s')}",
     vapp_name_2: "vdc-2-sp-#{Time.now.strftime('%s')}",

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '0.0.3'
+  s.add_development_dependency 'vcloud-tools-tester', '0.1.0'
 end


### PR DESCRIPTION
As of version 0.1.0 of the vCloud Tools Tester gem, we must use the
`Vcloud::Tools::Tester::TestSetup#test_params` method to retrieve test
parameters.

In doing so, that gem will ensure that the network fixtures are correct
in the vCloud organization that the integration tests run against.

Also, update the gemspec file to reflect this.

---

Note that I've intentionally left the `expected_user_params` argument
for `TestSetup#new` empty; this is new functionality that was added in
vCloud Tools Tester version 0.1.0 and is outside the scope of the
current story.
