### PR TITLE
[#72866380] Specify the required user-defined test params

### DIFF
--- a/spec/integration/launcher/launch_spec.rb
+++ b/spec/integration/launcher/launch_spec.rb
@@ -143,7 +143,18 @@ describe Vcloud::Launcher::Launch do
   def define_test_data
     config_file = File.join(File.dirname(__FILE__),
       "../vcloud_tools_testing_config.yaml")
-    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+    required_user_params = [
+      "vdc_1_name",
+      "catalog",
+      "vapp_template",
+      "storage_profile",
+      "network_1",
+      "network_2",
+      "network_1_ip",
+      "network_2_ip",
+    ]
+
+    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
     {
       vapp_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
       vdc_name: parameters.vdc_1_name,

--- a/spec/integration/launcher/storage_profile_integration_spec.rb
+++ b/spec/integration/launcher/storage_profile_integration_spec.rb
@@ -63,7 +63,19 @@ end
 def define_test_data
   config_file = File.join(File.dirname(__FILE__),
     "../vcloud_tools_testing_config.yaml")
-  parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+  required_user_parameters = [
+    "vdc_1_name",
+    "vdc_2_name",
+    "catalog",
+    "vapp_template",
+    "storage_profile",
+    "vdc_1_storage_profile_href",
+    "vdc_2_storage_profile_href",
+    "default_storage_profile_name",
+    "default_storage_profile_href",
+  ]
+
+  parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_parameters).test_params
   {
     vapp_name_1: "vdc-1-sp-#{Time.now.strftime('%s')}",
     vapp_name_2: "vdc-2-sp-#{Time.now.strftime('%s')}",


### PR DESCRIPTION
By specifying the user-defined test parameters we require for
each test, vCloud Tools Tester will fail fast if these
parameters are not defined.
