### PR TITLE
Use https when talking to rubygems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
A minor tweak I noticed whilst working on other things: it's good form to use https not http in rubygems `source` 
