### PR TITLE
Omit fs_file/fs_mntops from tests

### DIFF
--- a/spec/vcloud/launcher/preamble_spec.rb
+++ b/spec/vcloud/launcher/preamble_spec.rb
@@ -36,8 +36,8 @@ module Vcloud
             vars: { bob: 'Hello', mary: 'Hola' }
           },
           extra_disks: [
-            { size:  5120, fs_file: '/opt/test_disk1' },
-            { size: 10240, fs_file: '/opt/test_disk2' },
+            { name: 'test_disk1', size:  5120 },
+            { name: 'test_disk2', size: 10240 },
           ]
         }
       end

--- a/spec/vcloud/launcher/vm_orchestrator_spec.rb
+++ b/spec/vcloud/launcher/vm_orchestrator_spec.rb
@@ -26,10 +26,9 @@ describe Vcloud::Launcher::VmOrchestrator do
             :shutdown => true
         },
         :extra_disks => [
-            {:size => '1024', :name => 'Hard disk 2', :fs_file => 'mysql', :fs_mntops => 'mysql-something'},
-            {:size => '2048', :name => 'Hard disk 3', :fs_file => 'solr', :fs_mntops => 'solr-something'}
+            {:name => 'Hard disk 2', :size => '1024'},
+            {:name => 'Hard disk 3', :size => '2048'},
         ],
-
         :network_connections => [
             {:name => "network1", :ip_address => "198.12.1.21"},
         ],


### PR DESCRIPTION
The `fs_file` and `fs_mntops` fields for `extra_disks` don't currently
feature in Vcloud::Launcher::Schema::VM which validates our input files.

There was a discussion in gds-operations/vcloud-launcher#5 about whether one
of them should be added, but it dropped to the wayside. My personal feeling
is that site-specific preamble details shouldn't leak back into the main
schema. It might more appropriate to use a hash in boostrap[:vars] which is
keyed against extra_disks[:name].

In the meantime though our examples shouldn't refer to things that aren't in
the schema. So remove these references in tests that just check one thing
has been passed to another thing _after_ schema validation has occurred.

This does raise an interesting point though; how do we keep these up to
date as the schema changes? Does it matter?

/cc @bazbremner 
