### PR TITLE
[#70162466] Bump dependency on vCloud Core version without fog

### DIFF
--- a/lib/vcloud/launcher.rb
+++ b/lib/vcloud/launcher.rb
@@ -1,4 +1,3 @@
-require 'vcloud/fog'
 require 'vcloud/core'
 
 require 'vcloud/launcher/cli'

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.9.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.10.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 0.1.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 0.2.0'
 end


### PR DESCRIPTION
I did this to avoid later trouble that might be caused by updating vCloud Core to >= 0.10.0 without updating vCloud Tools Tester to >= 0.2.0, as there is a circular dependency. SO I thought I was doing a favour to later developers. However, it turns out that there was a stray inclusion of `vcloud/fog` here, so it's a good job I did this, and actually I'm just finishing the job I started :)
