### PR TITLE
Run a post-launch-cmd on VAPP launch

### DIFF
--- a/lib/vcloud/launcher/cli.rb
+++ b/lib/vcloud/launcher/cli.rb
@@ -11,6 +11,7 @@ module Vcloud
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => false,
         }
 
@@ -68,6 +69,14 @@ Example configuration files can be found in:
             @options["quiet"] = true
           end
 
+          opts.on("-p COMMAND", "--post-launch-cmd COMMAND", "Executable to run when a VM is successfully provisioned") do |command|
+            if command.split().length() != 1
+              exit_error_usage("COMMAND only accepts an executable name, not a command with arguments")
+            else
+              @options["post-launch-cmd"] = command
+            end
+          end
+
           opts.on("-v", "--verbose", "Verbose output") do
             @options["verbose"] = true
           end
@@ -86,7 +95,7 @@ Example configuration files can be found in:
         @usage_text = opt_parser.to_s
         begin
           opt_parser.parse!(args)
-        rescue OptionParser::InvalidOption => e
+        rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
           exit_error_usage(e)
         end
 

--- a/spec/integration/launcher/data/false_cmd
+++ b/spec/integration/launcher/data/false_cmd
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 1

--- a/spec/integration/launcher/data/true_cmd
+++ b/spec/integration/launcher/data/true_cmd
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/spec/integration/launcher/launch_spec.rb
+++ b/spec/integration/launcher/launch_spec.rb
@@ -31,6 +31,53 @@ describe Vcloud::Launcher::Launch do
     end
   end
 
+  context "when running successful post-launch commands" do
+    it 'should log that it ran the command' do
+      @test_data = define_test_data
+      @config_yaml = ErbHelper.convert_erb_template_to_yaml(@test_data, File.join(File.dirname(__FILE__), 'data/minimum_data_setup.yaml.erb'))
+
+      # Stub out other debug messages to prevent expectation failing to match
+      Vcloud::Core.logger.stub(:debug).with(anything())
+
+      # Expectation must be set before first use of Vcloud::Core.logger
+      expect(Vcloud::Core.logger).to receive(:debug).with(/Ran.*with VAPP_DEFINITION/)
+
+      @api_interface = Vcloud::Core::ApiInterface.new
+
+      Vcloud::Launcher::Launch.new(@config_yaml, { "continue-on-error" => false, "dont-power-on" => true, "post-launch-cmd" => File.join(File.dirname(__FILE__), 'data/true_cmd') }).run
+
+      @vapp_query_result = @api_interface.get_vapp_by_name_and_vdc_name(@test_data[:vapp_name], @test_data[:vdc_name])
+      @vapp_id = @vapp_query_result[:href].split('/').last
+
+      unless ENV['VCLOUD_TOOLS_RSPEC_NO_DELETE_VAPP']
+        File.delete @config_yaml
+        expect(@api_interface.delete_vapp(@vapp_id)).to eq(true)
+      end
+    end
+  end
+
+  context "When running unsuccessful post-launch commands" do
+    it 'should give an appropriate error message' do
+      @test_data = define_test_data
+      @config_yaml = ErbHelper.convert_erb_template_to_yaml(@test_data, File.join(File.dirname(__FILE__), 'data/minimum_data_setup.yaml.erb'))
+
+      # Expectation must be set before first use of Vcloud::Core.logger
+      expect(Vcloud::Core.logger).to receive(:error).with(/Failed to run/)
+
+      @api_interface = Vcloud::Core::ApiInterface.new
+
+      Vcloud::Launcher::Launch.new(@config_yaml, { "continue-on-error" => false, "dont-power-on" => true, "post-launch-cmd" => File.join(File.dirname(__FILE__), 'data/false_cmd') }).run
+
+      @vapp_query_result = @api_interface.get_vapp_by_name_and_vdc_name(@test_data[:vapp_name], @test_data[:vdc_name])
+      @vapp_id = @vapp_query_result[:href].split('/').last
+
+      unless ENV['VCLOUD_TOOLS_RSPEC_NO_DELETE_VAPP']
+        File.delete @config_yaml
+        expect(@api_interface.delete_vapp(@vapp_id)).to eq(true)
+      end
+    end
+  end
+
   context "happy path" do
     before(:all) do
       @test_data = define_test_data

--- a/spec/vcloud/launcher/cli_spec.rb
+++ b/spec/vcloud/launcher/cli_spec.rb
@@ -51,6 +51,7 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => false,
         }
       }
@@ -65,6 +66,7 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => true,
           "continue-on-error" => false,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => false,
         }
       }
@@ -79,6 +81,7 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => false,
           "continue-on-error" => true,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => false,
         }
       }
@@ -93,6 +96,7 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => true,
+          "post-launch-cmd"   => false,
           "verbose"           => false,
         }
       }
@@ -107,6 +111,7 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => true,
         }
       }
@@ -121,11 +126,43 @@ describe Vcloud::Launcher::Cli do
           "dont-power-on"     => false,
           "continue-on-error" => true,
           "quiet"             => false,
+          "post-launch-cmd"   => false,
           "verbose"           => true,
         }
       }
 
       it_behaves_like "a good CLI command"
+    end
+
+    context "when asked to run a command on launch" do
+      let(:args) { [ config_file, "--post-launch-cmd", "GIRAFFE" ] }
+      let(:cli_options) {
+        {
+          "dont-power-on"     => false,
+          "continue-on-error" => false,
+          "quiet"             => false,
+          "post-launch-cmd"   => 'GIRAFFE',
+          "verbose"           => false,
+        }
+      }
+
+      it_behaves_like "a good CLI command"
+    end
+
+    context "specifying a command with arguments to run on launch" do
+      let(:args) { [ config_file, "--post-launch-cmd", "GIRAFFE LION" ] }
+      let(:cli_options) {
+        {
+          "dont-power-on"     => false,
+          "continue-on-error" => false,
+          "quiet"             => false,
+          "post-launch-cmd"   => 'GIRAFFE LION',
+          "verbose"           => false,
+        }
+      }
+      it "exits with a error code, because this is not supported" do
+        expect(subject.exitstatus).not_to eq(0)
+      end
     end
 
     context "when asked to display version" do


### PR DESCRIPTION
See also: #77 - Apparently if I force push I can't reopen a PR which is annoying!

> In order to trigger actions when a VM is launched, we should be able to
> specify an arbitrary script to run which receives information about the
> VAPP via environment variables and is capable of executing further
> actions (such as notifying other systems that the VM has been created).

This commit adds the -p flag which will run the executable specified on VAPP launch. It will pass the entire vapp_definition hash as the VAPP_DEFINITION environment variable and the script will need to process that for further information.

This is simply just a tidied up commit history which already addressed all the comments in #77 

This is for [#66416966](https://www.pivotaltracker.com/story/show/66416966)
