### PR TITLE
[GH-82] Updated README regarding IP pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ provisions the vApps and VMs contained within.
 - Source vApp Template must contain a single VM. This is VMware's recommended
 'simple' method of vApp creation. Complex multi-VM vApps are not supported.
 - Org vDC Networks must be precreated.
-- IP addresses are assigned manually (recommended) or via DHCP. VM IP pools are
-not supported.
 - vCloud has some interesting ideas about the size of potential 'guest
 customisation scripts' (aka preambles). You may need to use an external minify
 tool to reduce the size, or speak to your provider to up the limit. 2048 bytes


### PR DESCRIPTION
PR #39 "Support for VM IP pools" removed the limitation that vcloud-launcher
don't supported pools, but the README was not uppdated to reflect this.
