### PR TITLE
[ Fixes #58 ] Remove DEBUG environment variable from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ If you want to be sure you are pinning to 5.1, or use 5.5, you can set the API v
 
 `export EXCON_DEBUG=true` - this will print out the API requests and responses.
 
-`export DEBUG=true` - this will show you the stack trace when there is an exception instead of just the message.
-
 ## Testing
 
 Run the default suite of tests (e.g. lint, unit, features):


### PR DESCRIPTION
As of commit 9c9b0159, any exceptions raised are rescued and therefore
back traces will never be printed regardless of the `DEBUG` environment
variable being set.

If users find `DEBUG` useful, we can look at adding the functionality
back. For now, we should make sure the documentation is accurate.