### PR TITLE
Only guest customize if there is something to customize

### DIFF
--- a/lib/vcloud/launcher/vm_orchestrator.rb
+++ b/lib/vcloud/launcher/vm_orchestrator.rb
@@ -23,7 +23,7 @@ module Vcloud
 
         preamble = vm_config[:bootstrap] ? generate_preamble(vm_config) : ''
 
-        @vm.configure_guest_customization_section(preamble) unless preamble.empty?
+        @vm.configure_guest_customization_section(preamble) if (!preamble.nil? && !preamble.empty?)
       end
 
       private

--- a/lib/vcloud/launcher/vm_orchestrator.rb
+++ b/lib/vcloud/launcher/vm_orchestrator.rb
@@ -23,7 +23,7 @@ module Vcloud
 
         preamble = vm_config[:bootstrap] ? generate_preamble(vm_config) : ''
 
-        @vm.configure_guest_customization_section(preamble) if (!preamble.nil? && !preamble.empty?)
+        @vm.configure_guest_customization_section(preamble) unless preamble.nil? || preamble.empty?
       end
 
       private

--- a/lib/vcloud/launcher/vm_orchestrator.rb
+++ b/lib/vcloud/launcher/vm_orchestrator.rb
@@ -23,7 +23,7 @@ module Vcloud
 
         preamble = vm_config[:bootstrap] ? generate_preamble(vm_config) : ''
 
-        @vm.configure_guest_customization_section(preamble)
+        @vm.configure_guest_customization_section(preamble) unless preamble.empty?
       end
 
       private

--- a/spec/vcloud/launcher/vm_orchestrator_spec.rb
+++ b/spec/vcloud/launcher/vm_orchestrator_spec.rb
@@ -136,8 +136,8 @@ describe Vcloud::Launcher::VmOrchestrator do
         subject.customize(vm_config_without_bootstrap)
       end
 
-      it "uses an empty string as the host preamble" do
-        expect(vm).to receive(:configure_guest_customization_section).with('')
+      it "skips customization if nothing to customize" do
+        expect(vm).not_to receive(:configure_guest_customization_section)
         subject.customize(vm_config_without_bootstrap)
       end
     end


### PR DESCRIPTION
We may not want to run guest customization on everything if there is no need to. Plus, not everything may be able to be customized i.e. coreos