### PR TITLE
Add machine-name option to launch a single machine

### DIFF
--- a/lib/vcloud/launcher/cli.rb
+++ b/lib/vcloud/launcher/cli.rb
@@ -8,6 +8,7 @@ module Vcloud
         @config_file = nil
         @usage_text = nil
         @options = {
+          "vapp-name"         => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
@@ -56,6 +57,10 @@ Example configuration files can be found in:
 
           opts.separator ""
           opts.separator "Options:"
+
+          opts.on('-n VAPP_NAME', '--vapp-name VAPP_NAME', 'Name of a single vApp to launch') do |vapp_name|
+            @options['vapp-name'] = vapp_name
+          end
 
           opts.on("-x", "--dont-power-on", "Do not power on vApps (default is to power on)") do
             @options["dont-power-on"] = true

--- a/lib/vcloud/launcher/launch.rb
+++ b/lib/vcloud/launcher/launch.rb
@@ -14,6 +14,8 @@ module Vcloud
         set_logging_level
         @config = config_loader.load_config(config_file, Vcloud::Launcher::Schema::LAUNCHER_VAPPS)
 
+        ignore_unspecified_machines
+
         validate_config
       end
 
@@ -72,6 +74,14 @@ module Vcloud
           Vcloud::Core.logger.level = Logger::ERROR
         else
           Vcloud::Core.logger.level = Logger::INFO
+        end
+      end
+
+      def ignore_unspecified_machines
+        if @cli_options["vapp-name"]
+          @config[:vapps].delete_if do |vapp|
+            vapp[:name] != @cli_options["vapp-name"]
+          end
         end
       end
 

--- a/spec/vcloud/launcher/cli_spec.rb
+++ b/spec/vcloud/launcher/cli_spec.rb
@@ -48,6 +48,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
@@ -63,6 +64,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--dont-power-on" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => true,
           "continue-on-error" => false,
           "quiet"             => false,
@@ -78,6 +80,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--continue-on-error" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => true,
           "quiet"             => false,
@@ -93,6 +96,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--quiet" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => true,
@@ -108,6 +112,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--verbose" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
@@ -123,6 +128,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--continue-on-error", "--verbose" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => true,
           "quiet"             => false,
@@ -138,6 +144,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--post-launch-cmd", "GIRAFFE" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,
@@ -153,6 +160,7 @@ describe Vcloud::Launcher::Cli do
       let(:args) { [ config_file, "--post-launch-cmd", "GIRAFFE LION" ] }
       let(:cli_options) {
         {
+          "vapp-name"      => false,
           "dont-power-on"     => false,
           "continue-on-error" => false,
           "quiet"             => false,

--- a/spec/vcloud/launcher/launch_spec.rb
+++ b/spec/vcloud/launcher/launch_spec.rb
@@ -51,6 +51,11 @@ describe Vcloud::Launcher::Launch do
         subject.new(config_file)
       end
 
+      it 'does not process non-matching machines if a single one is specified' do
+        subject.any_instance.should_receive(:ignore_unspecified_machines)
+        subject.new(config_file)
+      end
+
       it 'validates the configuration' do
         subject.any_instance.should_receive(:validate_config)
         subject.new(config_file)
@@ -137,6 +142,30 @@ describe Vcloud::Launcher::Launch do
         subject
       end
     end
+  end
+
+  describe '#ignore_unspecified_machines' do
+    subject { Vcloud::Launcher::Launch }
+
+    describe 'when the vApp name option is not specified' do
+      let(:cli_options) { {} }
+
+      it 'processes all machines' do
+        launch = subject.new(config_file, cli_options)
+        expect(launch.config[:vapps].length).to eq(3)
+      end
+    end
+
+    describe 'when a vApp name is specified as an option' do
+      let(:cli_options) { {"vapp-name" => "successful app 1"} }
+
+      it 'only processes the specified vApp' do
+        launch = subject.new(config_file, cli_options)
+        expect(launch.config[:vapps].length).to eq(1)
+        expect(launch.config[:vapps][0][:name]).to eq('successful app 1')
+      end
+    end
+
   end
 
   describe "configuration validation" do


### PR DESCRIPTION
When provisioning a new environment it's often simpler to build the first couple of machines one at a time rather than building all machines at once.

This commit adds an option to vcloud-launcher which only builds a single machine in the config file if the option is present.