### PR TITLE
Require OpenStruct in Vcloud::Launcher::Preamble

### DIFF
--- a/lib/vcloud/launcher/preamble.rb
+++ b/lib/vcloud/launcher/preamble.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Vcloud
   module Launcher
     class Preamble


### PR DESCRIPTION
The build fails when using an updated version of fog-core (v1.31.1 rather than v1.30.0). The error is:

```
NameError: uninitialized constant Vcloud::Launcher::Preamble::OpenStruct
./lib/vcloud/launcher/preamble.rb:40:in `interpolate_erb_file'
```

Adding an explicit require of OpenStruct fixes the failing tests.

https://github.com/fog/fog-core/compare/v1.30.0...v1.31.1