### PR TITLE
Update vcloud-core from 1.0.0 to 1.1.0

### DIFF
--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.0.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.1.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This fixes an issue where vcloud-core was not requiring the JSON module explicitly, causing tests to fail.