### PR TITLE
Bump version from v1.0.0 to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.0 (2015-07-09)
+
+  - Add optional MAC address to the schema for a VM
+  - Only run guest customization when there is something to customise
+  - Fix bug where OpenStruct must be explicity required
+  - Bump dependency on vcloud-core from 1.0.0 to 1.1.0
+
 ## 1.0.0 (2015-01-22)
 
   - Release 1.0.0 since the public API is now stable.

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
I'm not totally sure that this should be a minor version bump rather than a patch - the MAC address schema change was what put me over the edge.

https://github.com/gds-operations/vcloud-launcher/compare/gds-operations:81457a5...gds-operations:f0e1505