### PR TITLE
Specify RBENV_VERSION for Jenkins

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
 
+export RBENV_VERSION="2.1.2"
+
 ./jenkins_tests.sh
 bundle exec rake publish_gem


### PR DESCRIPTION
We don't install a system version of bundler on our CI machines anymore, so running `jenkins.sh` gives:

```
rbenv: bundle: command not found
```

As this is a Gem we don't want to add a `.ruby-version` file - we just want to specify the version of Ruby to run when running the tests.