### PR TITLE
Relax dependency on vcloud-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Unreleased
+## 2.0.0 (2015-10-20)
 
   - Remove support for Ruby 1.9.3, which is now end-of-life.
+  - Relax dependency on vCloud Core to make it easier to install
+    alongside other vCloud gems.
 
 ## 1.2.0 (2015-08-28)
 

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '1.2.0'
+    VERSION = '2.0.0'
   end
 end

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.1.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Relaxing the dependency on vcloud-core ensures that we still have
all the required bugfixes from the core gem while also making it
easier to install this gem in the same bundle as the other vCloud
gems.