### PR TITLE
Remove support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+  - Remove support for Ruby 1.9.3, which is now end-of-life.
+
 ## 1.2.0 (2015-08-28)
 
   - Add a `--vapp-name` option to launch a single machine


### PR DESCRIPTION
Ruby version 1.9.3 is no longer supported as of February 2015, and is no
longer supported by vcloud-core as of 1a26f58d.