### PR TITLE
Explicitly set rbenv version 2.0.0

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export RBENV_VERSION="2.1.2"
-
 ./jenkins_tests.sh
+
+source ./rbenv_version.sh
 bundle exec rake publish_gem

--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -18,6 +18,8 @@ ${FOG_CREDENTIAL}:
   vcloud_director_password: ''
 EOF
 
+source ./rbenv_version.sh
+
 git clean -ffdx
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,0 +1,1 @@
+export RBENV_VERSION="2.0.0"


### PR DESCRIPTION
__Depends on https://github.com/gds-operations/vcloud-launcher/pull/108__

Explicitly set the rbenv version to 2.0.0, the oldest version we
support, in both `jenkins.sh` and `jenkins_tests.sh`.

Run the tests using the oldest version so as to increase the likelihood
that we'll catch changes that break backwards compatibility.

Use a `rbenv_version.sh` file to avoid duplicating the version number.
I've avoided using `.ruby-version` file, which is supported by rbenv, to
avoid the implication that the version mentioned in `.ruby-version` is
the only one supported by the project.