### PR TITLE
Update required_ruby_version in gemspec

### DIFF
--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_runtime_dependency 'vcloud-core', '~> 1.1.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
This project only supports Ruby 2.0.0 and later.

Support for 1.9.3 was removed in ed1e2264147fc9ede9a38f4546ec49c7d33bdf74.