### PR TITLE
Add dry-run option to Launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - 2.1.2
 notifications:
   email: false
+sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1 (2016-03-24)
+
+  - Add dry-run option.
+  - Update dependencies for vCloud Core and vCloud Tools Tester
+
 ## 2.0.0 (2015-10-20)
 
   - Remove support for Ruby 1.9.3, which is now end-of-life.

--- a/lib/vcloud/launcher/cli.rb
+++ b/lib/vcloud/launcher/cli.rb
@@ -14,6 +14,7 @@ module Vcloud
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => false,
+          "dry-run"           => false,
         }
 
         parse(argv_array)
@@ -94,6 +95,10 @@ Example configuration files can be found in:
           opts.on("--version", "Display version and exit") do
             puts Vcloud::Launcher::VERSION
             exit
+          end
+
+          opts.on("--dry-run", "Don't apply configuration changes") do
+            @options["dry-run"] = true
           end
         end
 

--- a/lib/vcloud/launcher/launch.rb
+++ b/lib/vcloud/launcher/launch.rb
@@ -23,17 +23,20 @@ module Vcloud
         @config[:vapps].each do |vapp_config|
           Vcloud::Core.logger.info("Provisioning vApp #{vapp_config[:name]}.")
           begin
-            vapp = ::Vcloud::Launcher::VappOrchestrator.provision(vapp_config)
-            vapp.power_on unless cli_options["dont-power-on"]
-            if cli_options["post-launch-cmd"]
-              run_command(vapp_config, cli_options["post-launch-cmd"])
+            if cli_options["dry-run"]
+              vapp = ::Vcloud::Launcher::VappOrchestrator.provision(vapp_config, true)
+            else
+              vapp = ::Vcloud::Launcher::VappOrchestrator.provision(vapp_config)
+              vapp.power_on unless cli_options["dont-power-on"]
+              if cli_options["post-launch-cmd"]
+                run_command(vapp_config, cli_options["post-launch-cmd"])
+              end
             end
-            Vcloud::Core.logger.info("Provisioned vApp #{vapp_config[:name]} successfully.")
+          Vcloud::Core.logger.info("Provisioned vApp #{vapp_config[:name]} successfully.")
           rescue RuntimeError => e
             Vcloud::Core.logger.error("Failure: Could not provision vApp: #{e.message}")
             break unless cli_options["continue-on-error"]
           end
-
         end
       end
 

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/spec/vcloud/launcher/cli_spec.rb
+++ b/spec/vcloud/launcher/cli_spec.rb
@@ -54,6 +54,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
 
@@ -70,6 +71,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
 
@@ -86,6 +88,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
 
@@ -102,6 +105,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => true,
           "post-launch-cmd"   => false,
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
 
@@ -118,6 +122,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => true,
+          "dry-run"           => false,
         }
       }
 
@@ -134,6 +139,24 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => false,
           "verbose"           => true,
+          "dry-run"           => false,
+        }
+      }
+
+      it_behaves_like "a good CLI command"
+    end
+
+    context "when asked to do a dry-run" do
+      let(:args) { [ config_file, "--dry-run" ] }
+      let(:cli_options) {
+        {
+          "vapp-name"      => false,
+          "dont-power-on"     => false,
+          "continue-on-error" => false,
+          "quiet"             => false,
+          "post-launch-cmd"   => false,
+          "verbose"           => false,
+          "dry-run"           => true,
         }
       }
 
@@ -150,6 +173,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => 'GIRAFFE',
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
 
@@ -166,6 +190,7 @@ describe Vcloud::Launcher::Cli do
           "quiet"             => false,
           "post-launch-cmd"   => 'GIRAFFE LION',
           "verbose"           => false,
+          "dry-run"           => false,
         }
       }
       it "exits with a error code, because this is not supported" do

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.1'
+  s.add_runtime_dependency 'vcloud-core', '~> 2.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 1.0.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 2.0.0'
 end


### PR DESCRIPTION
This adds a dry-run option in so we can see which machines already exist and which machines will be created afresh as per the vapp config.

This was created as per the [issue raised here](https://github.com/gds-operations/vcloud-launcher/issues/94)

---

For testing, I created a fake machine which I ran it against to show the output. In this case, `foo-1`:

```
$ bundle exec vcloud-launch --dry-run ~/test.yaml --vapp-name foo-1
I, [2016-04-22T14:52:23.563213 #35311]  INFO -- : Provisioning vApp foo-1.
I, [2016-04-22T14:52:24.848296 #35311]  INFO -- : Instantiating new vApp foo-1 in vDC 'GOV.UK Frontend'
I, [2016-04-22T14:52:24.848402 #35311]  INFO -- : Provisioned vApp foo-1 successfully.
```

It successfully checks to see if it exists, and if it doesn't puts output saying that it's instantiating. You can see by the time output it has not actually provisioned a new vApp. If we were to use an app that already exists it'll let us know:

```
bundle exec vcloud-launch --dry-run ~/test.yaml --vapp-name frontend-1
I, [2016-04-22T14:56:52.995442 #35353]  INFO -- : Provisioning vApp frontend-1.
I, [2016-04-22T14:56:53.949723 #35353]  INFO -- : Found existing vApp frontend-1 in vDC 'GOV.UK Frontend'. Skipping.
I, [2016-04-22T14:56:53.949876 #35353]  INFO -- : Provisioned vApp frontend-1 successfully.
```