### PR TITLE
Changing example IPs to use private address ranges.

### DIFF
--- a/examples/vcloud-launch/complete_vapp_config.yaml
+++ b/examples/vcloud-launch/complete_vapp_config.yaml
@@ -9,7 +9,7 @@
 #  * its memory reconfigured to 4096MB
 #  * its cpu count reconfigured to be 2.
 #  * The Primary NIC will be moved to FrontendNetwork, and given a manual ip
-#    of 192.0.2.10
+#    of 192.168.2.10
 #  * A Secondary NIC will be created on BackendNetwork and given an IP address
 #    via DHCP (the result of not supplying an ip_address parameter)
 #  * a bootstrap 'guest customization script' is provided, which will be
@@ -37,7 +37,7 @@ vapps:
         cpu: 2
       network_connections:
       - name: 'FrontendNetwork'
-        ip_address: '192.0.2.10'
+        ip_address: '192.168.2.10'
       - name: 'BackendNetwork'
         allocation_mode: 'pool'
       extra_disks:

--- a/examples/vcloud-launch/multiple_vapps_simple.yaml
+++ b/examples/vcloud-launch/multiple_vapps_simple.yaml
@@ -18,7 +18,7 @@ vapps:
       cpu: '2'
     network_connections:
     - name: Default
-      ip_address: 192.0.2.11
+      ip_address: 192.168.2.11
 
 - name: vapp-example-2
   vdc_name: "Our VDC1"
@@ -30,7 +30,7 @@ vapps:
       cpu: '2'
     network_connections:
     - name: Default
-      ip_address: 192.0.2.12
+      ip_address: 192.168.2.12
 
 - name: vapp-example-3
   vdc_name: "Our VDC1"
@@ -42,4 +42,4 @@ vapps:
       cpu: '2'
     network_connections:
     - name: Default
-      ip_address: 192.0.2.13
+      ip_address: 192.168.2.13

--- a/examples/vcloud-launch/yaml_anchors_example.yaml
+++ b/examples/vcloud-launch/yaml_anchors_example.yaml
@@ -55,15 +55,15 @@ vapps:
         <<: *BASE_VM_VARS
         role: frontend
     network_connections:
-    - { name: *APP_NETWORK,  ip_address: 192.0.2.11 }
-    - { name: *MGMT_NETWORK, ip_address: 198.51.100.11 }
+    - { name: *APP_NETWORK,  ip_address: 192.168.2.11 }
+    - { name: *MGMT_NETWORK, ip_address: 192.168.100.11 }
 - <<: *frontend_vapp
   name: frontend-example-2
   vm:
     <<: *frontend_vm
     network_connections:
-    - { name: *APP_NETWORK,  ip_address: 192.0.2.12 }
-    - { name: *MGMT_NETWORK, ip_address: 198.51.100.12 }
+    - { name: *APP_NETWORK,  ip_address: 192.168.2.12 }
+    - { name: *MGMT_NETWORK, ip_address: 192.168.100.12 }
 
 - &backend_vapp
   <<: *BASE_VAPP
@@ -76,12 +76,12 @@ vapps:
         <<: *BASE_VM_VARS
         role: backend
     network_connections:
-    - { name: *APP_NETWORK,  ip_address: 192.0.2.51 }
-    - { name: *MGMT_NETWORK, ip_address: 198.51.100.51 }
+    - { name: *APP_NETWORK,  ip_address: 192.168.2.51 }
+    - { name: *MGMT_NETWORK, ip_address: 192.168.100.51 }
 - <<: *backend_vapp
   name: backend-example-2
   vm:
     <<: *backend_vm
     network_connections:
-    - { name: *APP_NETWORK,  ip_address: 192.0.2.52 }
-    - { name: *MGMT_NETWORK, ip_address: 198.51.100.52 }
+    - { name: *APP_NETWORK,  ip_address: 192.168.2.52 }
+    - { name: *MGMT_NETWORK, ip_address: 192.168.100.52 }


### PR DESCRIPTION
Documentation and examples should not be using public IP ranges, they
should be using private IPs as people using the examples will not have
access/own the listed public IP addresses.