### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0 (2017-06-22)
+
+  - Remove support for older versions of Ruby than 2.2.2
+  - Add support for Ruby 2.3.0 and 2.4.0
+  - Update dependency for vCloud Core and vCloud Tools Tester
+  - Various bug fixes
+
 ## 2.0.1 (2016-03-24)
 
   - Add dry-run option.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '2.0.1'
+    VERSION = '2.1.0'
   end
 end

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_runtime_dependency 'vcloud-core', '~> 2.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'

--- a/vcloud-launcher.gemspec
+++ b/vcloud-launcher.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 2.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 2.1.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
@@ -28,5 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>= 3.6'
   s.add_development_dependency 'rubocop', '~> 0.49.1'
   s.add_development_dependency 'simplecov', '~> 0.14.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 2.0.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 2.1.0'
 end


### PR DESCRIPTION
  - Remove support for older versions of Ruby than 2.2.2
  - Add support for Ruby 2.3.0 and 2.4.0
  - Update dependency for vCloud Core and vCloud Tools Tester
  - Various bug fixes

This PR also updates some dependencies.

https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools