### PR TITLE
Monkey patch older versions of fog and vcloud-launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.1 (2017-07-14)
+
+Maintenance
+
+  - Backport fog fix to support 'queued' status from vCloud API
+
 ## 0.7.0 (2014-12-05)
 
 Features:

--- a/bin/vcloud-launch
+++ b/bin/vcloud-launch
@@ -2,4 +2,35 @@
 
 require 'vcloud/launcher'
 
+FogVersion = Fog::VERSION.split('.')
+
+if ( FogVersion[0].to_i == 1 ) && ( FogVersion[1].to_i < 33 )
+  require 'fog/vcloud_director/models/compute/task'
+  if Fog::Compute::VcloudDirector::Task.method_defined?(:non_running?)
+    puts "Monkey patching Fog::Compute::VcloudDirector::Task.non_running?()"
+    module Fog
+      module Compute
+        class VcloudDirector
+          class Task < Fog::Model
+            def non_running?
+              if @service.show_progress? && (@last_progress ||= 0) < 100
+                if status == 'running' || status == 'queued'
+                  Fog::Formatador.redisplay_progressbar(progress, 100, :label => operation_name, :started_at => start_time)
+                  @last_progress = progress
+                elsif status == 'success'
+                  Fog::Formatador.redisplay_progressbar(100, 100, :label => operation_name, :started_at => start_time)
+                  @last_progress = 100
+                end
+              end
+              ! %w(running queued).include?(status)
+            end
+          end
+        end
+      end
+    end
+  else
+    raise "Failed to monkey patch Fog::Compute::VcloudDirector::Task.non_running?()"
+  end
+end
+
 Vcloud::Launcher::Cli.new(ARGV).run

--- a/lib/vcloud/launcher/version.rb
+++ b/lib/vcloud/launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Launcher
-    VERSION = '0.7.0'
+    VERSION = '0.7.1'
   end
 end


### PR DESCRIPTION
Unfortunately we're stuck using an old version of vcloud-launcher and have
been caught between version incompatibilities.  To work around this the best
approach we have is to monkey patch the fog change so we can continue to work.

The addition of the 'queued' status was added in fog-1.33.0, however we're
currently stuck on fog-1.29.

I don't expect this change to be merged to master, so this is more to raise visibility
of the workaround we've applied and trigger any discussion that may be relevant.  It
may be desirable to release a v0.7.1 to rubygems.org, however I'm not familiar with
how that would work.